### PR TITLE
Looks like in some cases we still need output_notebook().

### DIFF
--- a/notebooks/foundational.ipynb
+++ b/notebooks/foundational.ipynb
@@ -68,6 +68,8 @@
     }
    ],
    "source": [
+    "from bokeh.io import output_notebook\n",
+    "output_notebook()\n",
     "import hr\n",
     "hr.visual.hr_diagram('berkeley20')"
    ]


### PR DESCRIPTION
Looks like where the loading of the notebook is only gets executed on certain paths, and not if you reload the page or come back to your notebook.