### PR TITLE
[EPO-462] Add ipyaladin dependency to hr-diagram-investigation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .ipynb_checkpoints
 *~
 __pycache__
+vendors

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.PHONY: all vendors ipyaladin_clone ipyaladin_extensions ipyaladin clean
+
+
+all: ipyaladin
+
+vendors:
+	mkdir -p ./vendors
+
+ipyaladin_clone:
+	-git clone https://github.com/cds-astro/ipyaladin.git ./vendors/ipyaladin
+
+ipyaladin_python:
+	cd ./vendors/ipyaladin/;pip install -e .
+
+ipyaladin_extensions:
+	jupyter nbextension enable --py widgetsnbextension
+	jupyter nbextension enable --py --sys-prefix ipyaladin
+	jupyter labextension install @jupyter-widgets/jupyterlab-manager
+	cd ./vendors/ipyaladin/js;jupyter labextension install
+
+ipyaladin: vendors ipyaladin_clone ipyaladin_python ipyaladin_extensions
+
+clean:
+	rm -rf ./vendors

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-bokeh
-jupyterlab
-notebook
-pandas
+astropy==3.0
+bokeh==0.12.14
+jupyterlab==0.31.12
+notebook==5.4.0
+pandas==0.22.0
+#ipyaladin==0.1.3 # install through make.


### PR DESCRIPTION
Use make to encapsulate a working deploy of ipyaladin for JupyterLab.

	modified:   .gitignore
	new file:   Makefile
	modified:   requirements.txt