### PR TITLE
[EPO-432] Wrap output_notebook call to bokeh.

### DIFF
--- a/notebooks/foundational.ipynb
+++ b/notebooks/foundational.ipynb
@@ -37,11 +37,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from bokeh.io import output_notebook\n",
-    "from bokeh.plotting import show\n",
-    "output_notebook(hide_banner=True)\n",
-    "\n",
     "import hr\n",
+    "hr.setup_notebook()\n",
     "hr.visual.hr_diagram_skyimage(\"berkeley20\")"
    ]
   },

--- a/notebooks/foundational_with_code.ipynb
+++ b/notebooks/foundational_with_code.ipynb
@@ -37,12 +37,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from bokeh.io import output_notebook\n",
-    "from bokeh.plotting import show\n",
-    "output_notebook(hide_banner=True)\n",
-    "\n",
     "import hr\n",
     "from hr.data import pprint  # pprint is an abbreviation for pretty print.\n",
+    "hr.setup_notebook()\n",
     "hr.visual.hr_diagram_skyimage(\"berkeley20\")"
    ]
   },

--- a/notebooks/hr/__init__.py
+++ b/notebooks/hr/__init__.py
@@ -1,2 +1,19 @@
 from .data import get_hr_data
 from .visual import hr_diagram
+
+import bokeh.io
+import bokeh.resources
+
+import logging
+
+
+def setup_notebook(debug=False):
+    """Called at the start of notebook execution to setup the environment.
+
+    This will configure bokeh, and setup the logging library to be
+    reasonable."""
+    bokeh.io.output_notebook(bokeh.resources.INLINE, hide_banner=True)
+
+    if debug:
+        logging.basicConfig(level=logging.DEBUG)
+        logging.debug('Running notebook in debug mode.')


### PR DESCRIPTION
We need a central init point anyway for notebooks, so let's make
one.  Let's start off by outputing the notebook in the correct
way.

The correct way right now means setting up the logging environment
properly, as well as calling output_notebook with inline resources,
to run our own JS from our own Bokeh install.