### PR TITLE
 [EPO-420] Initial implementation of interactive Jupyter widgets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 .PHONY: all vendors ipyaladin_clone ipyaladin_extensions ipyaladin clean
 
 
-all: ipyaladin
+all: ipyaladin jupyterlab_bokeh
 
 vendors:
 	mkdir -p ./vendors
+
+jupyterlab_bokeh:
+	jupyter labextension install jupyterlab_bokeh
 
 ipyaladin_clone:
 	-git clone https://github.com/cds-astro/ipyaladin.git ./vendors/ipyaladin

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Install
 
 ```bash
 pip install -r requirements.txt
-jupyter labextension install jupyterlab_bokeh
+make
 ```
 
 Extras

--- a/notebooks/demo.ipynb
+++ b/notebooks/demo.ipynb
@@ -1,0 +1,152 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipyaladin as ipyal\n",
+    "aladin= ipyal.Aladin(target='15 26 20.534 -57 02 14.74', fov=135, survey='P/Mellinger/color')\n",
+    "aladin"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aladin.add_moc_from_URL('http://datalab.noao.edu/HiPS/des_dr1/Moc.fits', {'color': 'violet', 'opacity': 0.3})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "moc_berkeley20 = {\"10\": [5859088]} # up one nside => {\"9\":[1464772]} "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aladin.add_moc_from_dict(moc_berkeley20, {'name': 'Berkeley 20', 'adaptativeDisplay': False})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aladin.target = 'Berkeley 20'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aladin.survey = 'P/SDSS9/color'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# HR Diagram selection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hr\n",
+    "import bokeh\n",
+    "from bokeh.io import output_notebook, show, push_notebook\n",
+    "output_notebook(bokeh.resources.INLINE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hr.visual.hr_diagram_selection()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipyaladin as ipyal\n",
+    "from astroquery.simbad import Simbad\n",
+    "import astropy.units as u\n",
+    "\n",
+    "Simbad.SIMBAD_URL = 'http://simbad.harvard.edu/simbad/sim-script'\n",
+    "table = Simbad.query_region(\"berkeley20\", radius=0.04 * u.deg)\n",
+    "table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aladin= ipyal.Aladin(fov= 0.10, target= 'berkeley20', survey='P/SDSS9/color')\n",
+    "aladin"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aladin.add_table(table)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/hr/data.py
+++ b/notebooks/hr/data.py
@@ -7,6 +7,7 @@ from astropy.coordinates import SkyCoord
 
 import pandas as pd
 
+
 class OpenCluster(object):
     ra = None
     dec = None
@@ -22,14 +23,14 @@ class Berkeley20(OpenCluster):
     http://simbad.u-strasbg.fr/simbad/sim-id?Ident=Berkeley20&submit=submit+id
     https://www.aanda.org/articles/aa/abs/2002/27/aa2476/aa2476.html
     """
-    coord = SkyCoord("05 32 37.0 +00 11 18", unit=(u.hourangle, u.deg),
+    coord = SkyCoord('05 32 37.0 +00 11 18', unit=(u.hourangle, u.deg),
                      distance=9000 * u.parsec)  # +- 480
     fe_h = -0.3
     tau = 5.5
     eb_v = 0.15
     Z = 0.008  # Z_sun
     d_modulus = 14.7  # (m - M)
-    name = "Berkeley 20"
+    name = 'Berkeley 20'
     image_path = 'notebooks/data/berkeley20-square.png'
     _dtype = [('id', 'i'), ('x', 'f'), ('y', 'f'),
               ('u_b', 'f'), ('b_v', 'f'), ('v_r', 'f'),
@@ -57,7 +58,7 @@ class Berkeley20(OpenCluster):
         with open('data/berkeley20-durgapal.dat', newline='') as f:
             lines = f.readlines()
             data = []
-            pattern = re.compile("^\s+|\s* \s*|\s+$")
+            pattern = re.compile('^\s+|\s* \s*|\s+$')
             for l in lines:
                 values = [v for v in pattern.split(l) if v]
                 V = float(values[3])
@@ -81,20 +82,21 @@ class Berkeley20(OpenCluster):
     def to_array(cls):
         with open('data/berkeley20-durgapal.dat', newline='') as f:
             lines = f.readlines()
-            data = np.empty((0,1), dtype=cls._dtype)
-            pattern = re.compile("^\s+|\s* \s*|\s+$")
+            data = np.empty((0, 1), dtype=cls._dtype)
+            pattern = re.compile('^\s+|\s* \s*|\s+$')
             for l in lines:
                 values = [v for v in pattern.split(l) if v]
                 newrow = cls._dtype_row(data, values)
                 data = np.row_stack((data, newrow))
             return data
 
+
 class NGC2849(OpenCluster):
     """
     paper: http://iopscience.iop.org/article/10.1086/424939/pdf
            https://academic.oup.com/mnras/article/430/1/221/984833
     """
-    coord = SkyCoord("09 19 23.0 -40 31 01", unit=(u.hourangle, u.deg),
+    coord = SkyCoord('09 19 23.0 -40 31 01', unit=(u.hourangle, u.deg),
                      distance=6110 * u.parsec)
 
     def stars(cls):
@@ -102,7 +104,7 @@ class NGC2849(OpenCluster):
             lines = f.readlines()
             lines = lines[2:]
             data = []
-            pattern = re.compile("^\s+|\s* \s*|\s+$")
+            pattern = re.compile('^\s+|\s* \s*|\s+$')
             for l in lines:
                 values = [v for v in pattern.split(l) if v]
                 V = float(values[7])
@@ -117,7 +119,7 @@ class NGC7790(OpenCluster):
     """
     paper: https://aas.aanda.org/articles/aas/pdf/2000/15/ds6060.pdf
     """
-    coord = SkyCoord("23 58 24.0 +61 12 30", unit=(u.hourangle, u.deg),
+    coord = SkyCoord('23 58 24.0 +61 12 30', unit=(u.hourangle, u.deg),
                      distance=3230 * u.parsec)
 
 
@@ -167,17 +169,17 @@ temps = [['O5', 37500, -1.47, -0.32],
 
 
 def get_hr_data(name):
-    if name.lower() == "berkeley20":
+    if name.lower() == 'berkeley20':
         data = Berkeley20()
-    elif name.lower() == "berkeley20_cds":
+    elif name.lower() == 'berkeley20_cds':
         b20 = Berkeley20()
         b20.stars = b20.cds_stars
         data = b20
-    elif name.lower() == "ngc2849":
+    elif name.lower() == 'ngc2849':
         data = NGC2849()
     else:
-        raise NotImplemented("Only berkeley20 and ngc2849 are "
-                             "implemented right now.")
+        raise NotImplemented('Only berkeley20 and ngc2849 are '
+                             'implemented right now.')
     if data:
         return data
 
@@ -205,7 +207,8 @@ def pprint(arr, columns=('temp', 'lum'),
     elif type(max_rows) is int:
         pd.set_option('display.max_rows', max_rows)
     pd.set_option('precision', precision)
-    df = pd.DataFrame(arr.flatten(), index=arr['id'].flatten(), columns=columns)
+    df = pd.DataFrame(arr.flatten(), index=arr['id'].flatten(),
+                      columns=columns)
     df.columns = names
     return df
 

--- a/notebooks/hr/science.py
+++ b/notebooks/hr/science.py
@@ -4,6 +4,7 @@ import math
 
 import numpy as np
 
+
 def distance(modulus):
     """
     """
@@ -65,15 +66,15 @@ def color(teffs):
     colors = []
     for t in teffs:
         if t >= 7500:
-            colors.append('#CAE1FF')
+            colors.append('blue_white')  # RGB:CAE1FF
         elif t >= 6000:
-            colors.append('#F6F6F6')
+            colors.append('white')  # RGB:F6F6F6
         elif t >= 5200:
-            colors.append('#FFFEB2')
+            colors.append('yellowish_white')  # RGB:FFFEB2
         elif t >= 3700:
-            colors.append('#FFB28B')
+            colors.append('pale_yellow_orange')  # RGB:FFB28B
         else:
-            colors.append('#FF9966')
+            colors.append('light_orange_red')  # RGB:FF9966
     return colors
 
 

--- a/notebooks/hr/visual.py
+++ b/notebooks/hr/visual.py
@@ -39,13 +39,13 @@ def _telescope_pointing_widget(cluster_name):
 
 
 def _diagram(plot_figure, source=None, color='black', line_color='#444444',
-             xaxis_label="B-V [mag]", yaxis_label='V [mag]', name=None):
+             xaxis_label='B-V [mag]', yaxis_label='V [mag]', name=None):
     """Use a :class:`~bokeh.plotting.figure.Figure` and x and y collections
     to create an H-R diagram.
     """
     logging.info(type(source))
     logging.info(source)
-    plot_figure.circle(x="x", y="y", source=source,
+    plot_figure.circle(x='x', y='y', source=source,
                        size=8, color=color, alpha=1, name=name,
                        line_color=line_color, line_width=0.5)
     plot_figure.xaxis.axis_label = xaxis_label
@@ -182,7 +182,7 @@ def hr_diagram_figure(cluster):
     x_range = [max(x) + max(x) * 0.05, min(x) - min(x) * 0.05]
     source = ColumnDataSource(data=dict(x=x, y=y, color=colors))
     pf = figure(y_axis_type='log', x_range=x_range, name='hr',
-                tools="box_select,lasso_select,reset",
+                tools='box_select,lasso_select,reset',
                 title='H-R Diagram for {0}'.format(cluster.name))
     _diagram(source=source, plot_figure=pf, name='hr',
              color={'field': 'color', 'transform': color_mapper},
@@ -242,7 +242,7 @@ def hr_diagram_skyimage(cluster_name):
     pf = hr_diagram_figure(cluster)
     pf_image = skyimage_figure(cluster)
     layout = column(text_input, _telescope_pointing_widget(cluster.name),
-                    row(pf_image, pf), sizing_mode="scale_width")
+                    row(pf_image, pf), sizing_mode='scale_width')
     show(layout)
 
 
@@ -330,7 +330,7 @@ def hr_diagram_selection(cluster_name):
              yaxis_label='Luminosity (solar units)')
     pf_selected = figure(y_axis_type='log', y_range=pf.y_range,
                          x_range=x_range,
-                         tools="reset",
+                         tools='reset',
                          title='H-R Diagram for {0}'.format(cluster.name))
     _diagram(source=source_selected, plot_figure=pf_selected, name='hr',
              color={'field': 'color', 'transform': color_mapper},

--- a/notebooks/hr/visual.py
+++ b/notebooks/hr/visual.py
@@ -1,13 +1,19 @@
 """Visual for H-R diagram investigations.
 """
+import logging
 import math
 import random
 
 from bokeh.layouts import row, column, widgetbox
-from bokeh.models import ColumnDataSource, Range1d
+from bokeh.models import CategoricalColorMapper, ColumnDataSource,\
+    CustomJS, LassoSelectTool, Range1d, ResetTool
 from bokeh.models.formatters import NumeralTickFormatter
 from bokeh.models.widgets import Slider, TextInput, Div
 from bokeh.plotting import figure, show
+
+from ipyaladin import Aladin
+
+from ipywidgets import Layout, Box, widgets
 
 import numpy
 
@@ -37,7 +43,9 @@ def _diagram(plot_figure, source=None, color='black', line_color='#444444',
     """Use a :class:`~bokeh.plotting.figure.Figure` and x and y collections
     to create an H-R diagram.
     """
-    plot_figure.circle(x=source.data.get('x'), y=source.data.get('y'),
+    logging.info(type(source))
+    logging.info(source)
+    plot_figure.circle(x="x", y="y", source=source,
                        size=8, color=color, alpha=1, name=name,
                        line_color=line_color, line_width=0.5)
     plot_figure.xaxis.axis_label = xaxis_label
@@ -170,12 +178,14 @@ def hr_diagram_figure(cluster):
     """
     temps, lums = teff(cluster), luminosity(cluster)
     x, y = temps, lums
-    colors = color(temps)
+    colors, color_mapper = hr_diagram_color_helper(temps)
     x_range = [max(x) + max(x) * 0.05, min(x) - min(x) * 0.05]
-    source = ColumnDataSource(data=dict(x=x, y=y))
-    pf = figure(y_axis_type='log', x_range=x_range,
+    source = ColumnDataSource(data=dict(x=x, y=y, color=colors))
+    pf = figure(y_axis_type='log', x_range=x_range, name='hr',
+                tools="box_select,lasso_select,reset",
                 title='H-R Diagram for {0}'.format(cluster.name))
-    _diagram(source=source, plot_figure=pf, name='hr', color=colors,
+    _diagram(source=source, plot_figure=pf, name='hr',
+             color={'field': 'color', 'transform': color_mapper},
              xaxis_label='Temperature (Kelvin)',
              yaxis_label='Luminosity (solar units)')
     return pf
@@ -201,26 +211,56 @@ def hr_diagram_from_data(data, x_range, y_range):
     """
     temps, lums = data['temp'], data['lum']
     x, y = temps, lums
-    colors = color(temps)
-    source = ColumnDataSource(data=dict(x=x, y=y))
+    colors, color_mapper = hr_diagram_color_helper(temps)
+    source = ColumnDataSource(data=dict(x=x, y=y, color=colors))
     pf = figure(y_axis_type='log', x_range=x_range, y_range=y_range)
-    _diagram(source=source, plot_figure=pf, name='hr', color=colors,
+    _diagram(source=source, plot_figure=pf, name='hr',
+             color={'field': 'color', 'transform': color_mapper},
              xaxis_label='Temperature (Kelvin)',
              yaxis_label='Luminosity (solar units)')
     show(pf)
+
+
+def cluster_text_input(cluster, title=None):
+    """
+    Create an :class:`~bokeh.models.widgets.TextInput` using
+    the cluster.name as the default value and title.
+
+    If no title is provided use, 'Type in the name of your cluster
+    and press Enter/Return:'.
+    """
+    if not title:
+        title = 'Type in the name of your cluster and press Enter/Return:'
+    return TextInput(value=cluster.name, title=title)
 
 
 def hr_diagram_skyimage(cluster_name):
     """
     """
     cluster = get_hr_data(cluster_name)
-    input_caption = 'Type in the name of your cluster and press Enter/Return:'
-    text_input = TextInput(value=cluster.name, title=input_caption)
+    text_input = cluster_text_input(cluster)
     pf = hr_diagram_figure(cluster)
     pf_image = skyimage_figure(cluster)
     layout = column(text_input, _telescope_pointing_widget(cluster.name),
                     row(pf_image, pf), sizing_mode="scale_width")
     show(layout)
+
+
+def ipywidget_box(bokeh_widget):
+    """
+    """
+    outw = widgets.Output()
+    display(outw)
+    return outw
+
+
+def hr_diagram_skyviewer(cluster_name):
+    """
+    """
+    cluster = get_hr_data(cluster_name)
+    text_input = cluster_text_input(cluster)
+    pf = hr_diagram_figure(cluster)
+    skyviewer = None
 
 
 def hr_diagram_interactive(doc):
@@ -251,3 +291,66 @@ def hr_diagram_interactive(doc):
 
     text_input.on_change('value', update_data)
     doc.add_root(layout)
+
+
+def hr_diagram_color_helper(temps):
+    colors = color(temps)
+    color_mapper = CategoricalColorMapper(
+        factors=['blue_white',
+                 'white',
+                 'yellowish_white',
+                 'pale_yellow_orange',
+                 'light_orange_red'],
+        palette=['#CAE1FF',
+                 '#F6F6F6',
+                 '#FFFEB2',
+                 '#FFB28B',
+                 '#FF9966'])
+    return colors, color_mapper
+
+
+def hr_diagram_selection(cluster_name):
+    """
+    Given a cluster create two Bokeh plot based H-R diagrams.
+    The Selection in the left H-R diagram will show up on the
+    right one.
+    """
+    cluster = get_hr_data(cluster_name)
+    temps, lums = teff(cluster), luminosity(cluster)
+    x, y = temps, lums
+    colors, color_mapper = hr_diagram_color_helper(temps)
+    x_range = [max(x) + max(x) * 0.05, min(x) - min(x) * 0.05]
+    source = ColumnDataSource(data=dict(x=x, y=y, color=colors), name='hr')
+    source_selected = ColumnDataSource(data=dict(x=[], y=[], color=[]),
+                                       name='hr')
+    pf = figure(y_axis_type='log', x_range=x_range,
+                tools='lasso_select,reset',
+                title='H-R Diagram for {0}'.format(cluster.name))
+    _diagram(source=source, plot_figure=pf, name='hr',
+             color={'field': 'color', 'transform': color_mapper},
+             xaxis_label='Temperature (Kelvin)',
+             yaxis_label='Luminosity (solar units)')
+    pf_selected = figure(y_axis_type='log', y_range=pf.y_range,
+                         x_range=x_range,
+                         tools="reset",
+                         title='H-R Diagram for {0}'.format(cluster.name))
+    _diagram(source=source_selected, plot_figure=pf_selected, name='hr',
+             color={'field': 'color', 'transform': color_mapper},
+             xaxis_label='Temperature (Kelvin)',
+             yaxis_label='Luminosity (solar units)')
+    source.callback = CustomJS(args=dict(source_selected=source_selected), code="""
+        var inds = cb_obj.selected['1d'].indices;
+        var d1 = cb_obj.data;
+        var d2 = source_selected.data;
+        console.log(inds);
+        d2['x'] = []
+        d2['y'] = []
+        d2['color'] = []
+        for (i = 0; i < inds.length; i++) {
+            d2['x'].push(d1['x'][inds[i]])
+            d2['y'].push(d1['y'][inds[i]])
+            d2['color'].push(d1['color'][inds[i]])
+        }
+        source_selected.change.emit();
+        """)
+    show(row(pf, pf_selected))

--- a/notebooks/interactive.ipynb
+++ b/notebooks/interactive.ipynb
@@ -1,0 +1,242 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipyaladin.aladin_widget as ipyal\n",
+    "aladin = ipyal.Aladin(target='Berkeley 20', fov=0.3, survey='P/SDSS9/color')\n",
+    "aladin"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import bokeh\n",
+    "from bokeh.io import output_notebook, show, push_notebook\n",
+    "output_notebook(bokeh.resources.INLINE)\n",
+    "\n",
+    "from hr.visual import _telescope_pointing_widget\n",
+    "from hr.visual import *\n",
+    "\n",
+    "def hr_diagram_skyimage(cluster_name, output):\n",
+    "    \"\"\"\n",
+    "    \"\"\"\n",
+    "    cluster = get_hr_data(cluster_name)\n",
+    "    input_caption = 'Type in the name of your cluster and press Enter/Return:'\n",
+    "    text_input = TextInput(value=cluster.name, title=input_caption)\n",
+    "    pf = hr_diagram_figure(cluster)\n",
+    "    pf_image = skyimage_figure(cluster)\n",
+    "    layout = column(text_input, _telescope_pointing_widget(cluster.name),\n",
+    "                    pf, sizing_mode=\"scale_width\")\n",
+    "    with output:\n",
+    "      h = show(layout, notebook_handle=True)\n",
+    "      return h\n",
+    "\n",
+    "outw = widgets.Output()\n",
+    "\n",
+    "q1 = widgets.VBox(children=[widgets.Label(\"1.\tWhat are the ranges of star temperatures and luminosities that you observed on your H-R diagram?\"), widgets.Textarea(rows=1)])\n",
+    "q1 = widgets.VBox(children=[widgets.Label(\"1.\tWhat are the ranges of star temperatures and luminosities that you observed on your H-R diagram?\"), widgets.Textarea(rows=1)])\n",
+    "q2 = widgets.VBox(children=[widgets.Label(\"2.\tWhere on the H-R diagram are the stars most concentrated? What is their color?\"), widgets.Textarea(rows=1)])\n",
+    "q3 = widgets.VBox(children=[widgets.Label(\"3.\tWhere on the H-R diagram are cool and dim stars located?\"), widgets.Textarea(rows=1)])\n",
+    "\n",
+    "# display widget!!!!\n",
+    "display(widgets.HBox(children=[outw, widgets.VBox([q1, q2, q3])]))\n",
+    "\n",
+    "h_comm = hr_diagram_skyimage(\"berkeley20\", outw)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "from bokeh.io import output_notebook, show, push_notebook\n",
+    "output_notebook(bokeh.resources.INLINE)\n",
+    "from bokeh.models import ColumnDataSource, Circle\n",
+    "import ipywidgets as widgets\n",
+    "from IPython.display import display\n",
+    "\n",
+    "plot = figure()\n",
+    "source = ColumnDataSource(\n",
+    "    data=dict(\n",
+    "        x=[1],\n",
+    "        y=[1],\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "circle = Circle(x=\"x\", y=\"y\", size=15, fill_color=\"blue\", fill_alpha=0.8, line_color=None)\n",
+    "plot.add_glyph(source, circle)\n",
+    "\n",
+    "q1 = widgets.VBox(children=[widgets.Label(\"1.\tWhat are the ranges of star temperatures and luminosities that you observed on your H-R diagram?\"), widgets.Textarea(rows=1)])\n",
+    "\n",
+    "outw = widgets.Output()\n",
+    "\n",
+    "# display widget!!!!\n",
+    "display(widgets.HBox(children=[outw, q1]))\n",
+    "\n",
+    "# plot into widget\n",
+    "with outw:\n",
+    "    h = show(plot, notebook_handle=True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ipyaladin import Aladin\n",
+    "\n",
+    "from ipywidgets import Layout, Box, widgets\n",
+    "\n",
+    "aladin = Aladin(layout=Layout(width='70%'), target='Berkeley 20', fov=0.3)\n",
+    "info = widgets.HTML()\n",
+    "\n",
+    "\n",
+    "box_layout = Layout(display='flex',\n",
+    "                    flex_flow='row',\n",
+    "                    align_items='stretch',\n",
+    "                    width='100%')\n",
+    "box = Box(children=[aladin, info], layout=box_layout)\n",
+    "box"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "import logging\n",
+    "data_list = []\n",
+    "def process_result(data):\n",
+    "    info.value = ''\n",
+    "    ra = data['ra']\n",
+    "    dec = data['dec']\n",
+    "    radius = min(aladin.fov / 10, 5)\n",
+    "    logging.warn(ra)\n",
+    "    logging.warn(dec)\n",
+    "    query = \"\"\"SELECT TOP 1 main_id, ra, dec, DISTANCE(POINT('ICRS', %f, %f), POINT('ICRS', ra, dec)) as d FROM basic\n",
+    "               WHERE CONTAINS(POINT('ICRS', ra, dec), CIRCLE('ICRS', %f, %f, %f))=1\n",
+    "               ORDER BY d ASC\"\"\" % (ra, dec, ra, dec, aladin.fov / 10)\n",
+    "    \n",
+    "    r = requests.get('http://simbad.u-strasbg.fr/simbad/sim-tap/sync', params={'query': query, 'request': 'doQuery', 'lang': 'adql', 'format': 'json', 'phase': 'run'})\n",
+    "    obj_name = ''\n",
+    "    obj_coo = None\n",
+    "    obj_data = r.json()['data']\n",
+    "    if len(obj_data)==0:\n",
+    "        return\n",
+    "    \n",
+    "    obj_name = obj_data[0][0]\n",
+    "    obj_coo = [obj_data[0][1], obj_data[0][2]]\n",
+    "    data_list.append(obj_data)\n",
+    "    sed_img = '<img src=\"http://cdsportal.u-strasbg.fr/cgi-bin/PhotVizPreview/plot?ra=%f&dec=%f&radius_arcsec=5&w=200&h=150&point_size=4\">' % (obj_coo[0], obj_coo[1])\n",
+    "    info.value =  '<h2>%s</h2><br><br>%s' % (obj_name, sed_img)\n",
+    "    \n",
+    "aladin.add_listener('click', process_result)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "source.data = {'x':[42], 'y':[42]}\n",
+    "push_notebook(handle=h)\n",
+    "h.comms"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aladin.add_table??"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import astropy\n",
+    "import healpy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import healpy as hp\n",
+    "from math import pi\n",
+    "def IndexToDeclRa(NSIDE, index):\n",
+    "    theta, phi = hp.pixelfunc.pix2ang(NSIDE,index)\n",
+    "    return -np.degrees(theta-pi/2.),np.degrees(math.pi*2.-phi)\n",
+    "IndexToDeclRa(9, 1464772)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import hr\n",
+    "import bokeh\n",
+    "from bokeh.io import output_notebook, show, push_notebook\n",
+    "output_notebook(bokeh.resources.INLINE)\n",
+    "hr.visual.hr_diagram_selection('berkeley20')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Implement fundamental interactive Jupyter widget prototypes. The `hr.visual.hr_diagram_interactive` method should support a combination of ipywidgets and Bokeh widgets. It also needs an interactive skyimage or skyviewer widget which will support annotations.

  * Add intermediate files `notebooks/demo.ipynb` and `notebooks/interactive.ipynb`.
  * Use source in _diagram instead of lists.
  * Use CategoricalColorMapper and include colors in source.
  * Combined Jupyter and Bokeh widgets using `Output`.
  * Add ipyaladin widget and some initial demos for it.
  * Implement `hr.visual.hr_diagram_selection` method.
  * PEP8 Compliance.

	new file:   notebooks/demo.ipynb
	modified:   notebooks/hr/data.py
	modified:   notebooks/hr/science.py
	modified:   notebooks/hr/visual.py
	new file:   notebooks/interactive.ipynb