### PR TITLE
[EPO-420] Add `ipywidgets.Output` support.

### DIFF
--- a/notebooks/demo.ipynb
+++ b/notebooks/demo.ipynb
@@ -83,7 +83,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hr.visual.hr_diagram_selection()"
+    "hr.visual.hr_diagram_selection(\"berkeley20\")"
    ]
   },
   {
@@ -109,15 +109,6 @@
    "source": [
     "aladin= ipyal.Aladin(fov= 0.10, target= 'berkeley20', survey='P/SDSS9/color')\n",
     "aladin"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "aladin.add_table(table)"
    ]
   },
   {

--- a/notebooks/hr/visual.py
+++ b/notebooks/hr/visual.py
@@ -148,13 +148,20 @@ def m_M_compare_interactive_ngc2849(doc):
     doc.title = 'Distance through μ'
 
 
-def hr_diagram(cluster_name):
+def hr_diagram(cluster_name, output=None):
     """Create a :class:`~bokeh.plotting.figure.Figure` to create an H-R
     diagram using the cluster_name; then show it.
+
+    Re
     """
     cluster = get_hr_data(cluster_name)
     pf = hr_diagram_figure(cluster)
-    show(pf)
+    if output:
+        with output:
+            h = show(pf, notebook_handle=True)
+    else:
+        h = show(pf, notebook_handle=True)
+    return h
 
 
 def skyimage_figure(cluster):

--- a/notebooks/interactive.ipynb
+++ b/notebooks/interactive.ipynb
@@ -208,14 +208,57 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "import bokeh\n",
+    "from bokeh.io import output_notebook, show, push_notebook\n",
+    "output_notebook(bokeh.resources.INLINE)\n",
+    "\n",
+    "import hr\n",
+    "from hr.visual import hr_diagram\n",
+    "\n",
+    "import ipyaladin.aladin_widget as ipyal\n",
+    "\n",
+    "import ipywidgets as widgets\n",
+    "\n",
+    "\n",
+    "box_layout = widgets.Layout(display='flex',\n",
+    "                    flex_flow='row',\n",
+    "                    align_items='stretch',\n",
+    "                    border='solid',\n",
+    "                    border_color='#FF2244',\n",
+    "                    width='50%',\n",
+    "                    height='50%')\n",
+    "aladin = ipyal.Aladin(target='Berkeley 20', fov=0.2, survey='P/SDSS9/color',\n",
+    "                      layout=box_layout)\n",
+    "outw = widgets.Output()\n",
+    "display(widgets.HBox(children=[aladin, outw]))\n",
+    "\n",
+    "h_comm = hr_diagram(\"berkeley20\", outw)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "import ipyaladin as ipyal\n",
+    "from astroquery.simbad import Simbad\n",
+    "import astropy.units as u\n",
+    "\n",
+    "Simbad.SIMBAD_URL = 'http://simbad.harvard.edu/simbad/sim-script'\n",
+    "table = Simbad.query_region(\"berkeley20\", radius=0.3 * u.deg)\n",
+    "table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aladin.add_table(table)"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
  * Pass in cluster_name argument to hr_diagram method in demo notebook.
  * Add example to interactive.ipynb which uses `ipywidgets.Output` to render
    Bokeh and Jupyter widgets in the same cell.

	modified:   notebooks/demo.ipynb
	modified:   notebooks/hr/visual.py
	modified:   notebooks/interactive.ipynb